### PR TITLE
Add support for setting custom Order ID for DCC Rate

### DIFF
--- a/src/main/java/com/global/api/paymentMethods/CreditCardData.java
+++ b/src/main/java/com/global/api/paymentMethods/CreditCardData.java
@@ -96,11 +96,16 @@ public class CreditCardData extends Credit implements ICardData {
     }
 
     public DccRateData getDccRate(DccRateType dccRateType, BigDecimal amount, String currency, DccProcessor ccp) throws ApiException {
+    	return getDccRate(dccRateType, amount, currency, ccp, null);
+	}
+    
+    public DccRateData getDccRate(DccRateType dccRateType, BigDecimal amount, String currency, DccProcessor ccp, String orderId) throws ApiException {
 		Transaction response = new AuthorizationBuilder(TransactionType.DccRateLookup, this)
 				.withAmount(amount)
 				.withCurrency(currency)
 				.withDccRateType(dccRateType)
 				.withDccProcessor(ccp)
+				.withOrderId(orderId)
 				.withDccType("1")
 				.execute();
 
@@ -112,7 +117,6 @@ public class CreditCardData extends Credit implements ICardData {
 		dccValues.setDccRate(response.getDccResponseResult().getCardHolderRate());
 		dccValues.setCurrency(response.getDccResponseResult().getCardHolderCurrency());
 		dccValues.setAmount(response.getDccResponseResult().getCardHolderAmount());
-
 		return dccValues;
 	}
 


### PR DESCRIPTION
Hi, I'm requesting to add the ability to add a custom Order ID for the DCC Rate via the SDK. Currently the Order ID cannot be set by the end user, a default Order ID is generated by the SDK during the creation of the Transaction. If a client wanted the Order ID to be consistent with the Payment ID, it would not be possible using the SDK as it stands.