### PR TITLE
Adds brand reference to the DisputeSummary

### DIFF
--- a/src/main/java/com/global/api/entities/reporting/DisputeSummary.java
+++ b/src/main/java/com/global/api/entities/reporting/DisputeSummary.java
@@ -47,6 +47,7 @@ public class DisputeSummary {
     private String transactionAuthCode;
     private String transactionCardType;
     private String transactionMaskedCardNumber;
+    private String transactionBrandReference;
     private String reason;
     private String reasonCode;
     private String result;

--- a/src/main/java/com/global/api/mapping/GpApiMapping.java
+++ b/src/main/java/com/global/api/mapping/GpApiMapping.java
@@ -805,6 +805,21 @@ public class GpApiMapping {
                 summary.setTransactionCardType(card.getString("brand"));
             }
         }
+        if (doc.has("transaction")) {
+            JsonDoc transaction = doc.get("transaction");
+            if (transaction.has("payment_method")) {
+                JsonDoc paymentMethod = transaction.get("payment_method");
+
+                if (paymentMethod.has("card")) {
+                    JsonDoc card = paymentMethod.get("card");
+
+                    summary.setTransactionMaskedCardNumber(card.getString("number"));
+                    summary.setTransactionARN(card.getString("arn"));
+                    summary.setTransactionCardType(card.getString("brand"));
+                    summary.setTransactionBrandReference(card.getString("brand_reference"));
+                }
+            }
+        }
 
         String timeToRespondBy = doc.getString("time_to_respond_by");
         if (!isNullOrEmpty(timeToRespondBy)) {

--- a/src/test/java/com/global/api/tests/gpapi/GpApiReportingDisputesTest.java
+++ b/src/test/java/com/global/api/tests/gpapi/GpApiReportingDisputesTest.java
@@ -1006,4 +1006,18 @@ public class GpApiReportingDisputesTest extends BaseGpApiReportingTest {
         }
     }
 
+    @Test
+    public void ReportDisputeDetail_brandReference() throws ApiException {
+        String disputeId = "DIS_SAND_abcd1234";
+
+        DisputeSummary response =
+                ReportingService
+                        .disputeDetail(disputeId)
+                        .execute();
+
+        assertNotNull(response);
+        assertEquals(disputeId, response.getCaseId());
+        assertEquals("23423421342323A", response.getTransactionBrandReference());
+    }
+
 }


### PR DESCRIPTION
When calling for a single dispute some transaction data are not mapped. Also brand reference was not available in the DisputeSummary object. 