### PR TITLE
Re-sign in after token expiration

### DIFF
--- a/src/test/java/com/global/api/tests/gpapi/GpApiAuthenticationTest.java
+++ b/src/test/java/com/global/api/tests/gpapi/GpApiAuthenticationTest.java
@@ -114,6 +114,40 @@ public class GpApiAuthenticationTest extends BaseGpApiTest {
     }
 
     @Test
+    public void shouldReSignInAfterTokenExpiration() throws ApiException, InterruptedException {
+        GpApiConfig gpApiConfig = configAccessTokenCall()
+                .setSecondsToExpire(60);
+
+        AccessTokenInfo accessTokenInfo = GpApiService.generateTransactionKey(gpApiConfig);
+
+        assertAccessTokenResponse(accessTokenInfo);
+
+        ServicesContainer.configureService(gpApiConfig, GP_API_CONFIG_NAME);
+
+        Transaction response =
+                card
+                        .verify()
+                        .withCurrency("USD")
+                        .execute(GP_API_CONFIG_NAME);
+
+        assertNotNull(response);
+        assertEquals(SUCCESS, response.getResponseCode());
+        assertEquals(VERIFIED, response.getResponseMessage());
+
+        Thread.sleep(61_000L);
+
+        response =
+                card
+                        .verify()
+                        .withCurrency("USD")
+                        .execute(GP_API_CONFIG_NAME);
+
+        assertNotNull(response);
+        assertEquals(SUCCESS, response.getResponseCode());
+        assertEquals(VERIFIED, response.getResponseMessage());
+    }
+
+    @Test
     public void GenerateAccessTokenManualWithMaximumSecondsToExpire() {
         GpApiConfig gpApiConfig = configAccessTokenCall()
                 .setSecondsToExpire(604801);


### PR DESCRIPTION
SignIn after token expires is not working correctly as authorization header (with expired token) is send with new call for access token, and 401 response is not recognized correctly. 