### PR TITLE
Refactor sendReady method to return void in DeviceInterface and UpaInterface

### DIFF
--- a/src/main/java/com/global/api/terminals/DeviceInterface.java
+++ b/src/main/java/com/global/api/terminals/DeviceInterface.java
@@ -200,7 +200,7 @@ public abstract class DeviceInterface<TResult extends DeviceController> implemen
     }
 
     @Override
-    public IDeviceResponse sendReady() throws ApiException {
+    public void sendReady() throws ApiException {
         throw new UnsupportedTransactionException(ERROR_MESSAGE);
     }
 

--- a/src/main/java/com/global/api/terminals/abstractions/IDeviceInterface.java
+++ b/src/main/java/com/global/api/terminals/abstractions/IDeviceInterface.java
@@ -107,7 +107,7 @@ public interface IDeviceInterface extends IDisposable {
 
     IDeviceResponse sendFile(SendFileType fileType, String filePath) throws ApiException;
 
-    IDeviceResponse sendReady() throws ApiException; //UPA
+    void sendReady() throws ApiException; //UPA
 
     IDeviceResponse setDebugLevel(DebugLevel[] debugLevels, Enum logToConsole) throws ApiException;
 

--- a/src/main/java/com/global/api/terminals/upa/UpaInterface.java
+++ b/src/main/java/com/global/api/terminals/upa/UpaInterface.java
@@ -204,13 +204,12 @@ public class UpaInterface extends DeviceInterface<UpaController> {
     }
 
     @Override
-    public IDeviceResponse sendReady() throws ApiException {
+    public void sendReady() throws ApiException {
         DeviceMessage message = TerminalUtilities.buildMessage(
                 READY_MESSAGE
         );
 
-        JsonDoc response = sendRequest(message);
-        return new UpaDeviceResponse(response);
+        _controller.send(message);
     }
 
     public IDeviceResponse registerPOS(RegisterPOS data) throws ApiException {

--- a/src/test/java/com/global/api/tests/terminals/upa/UpaAdminTests.java
+++ b/src/test/java/com/global/api/tests/terminals/upa/UpaAdminTests.java
@@ -119,8 +119,7 @@ public class UpaAdminTests {
 
     @Test
     public void test05_sendReady() throws ApiException {
-        IDeviceResponse iDeviceResponse = device.sendReady();
-        assertNotNull(iDeviceResponse);
+        device.sendReady();
     }
 
     @Test


### PR DESCRIPTION
Refactor sendReady method to return void in DeviceInterface and UpaInterface
